### PR TITLE
Remove password from config

### DIFF
--- a/labels.wmflabs.org.yaml
+++ b/labels.wmflabs.org.yaml
@@ -10,7 +10,7 @@ database:
   host: wikilabels-database
   user: wikilabels
   database: wikilabels
-  password: wikilabels-admin
+  password: ""
 
 oauth:
   mw_uri: https://www.mediawiki.org/w/index.php


### PR DESCRIPTION
Changed puppet code to initialize postgres trusty user with empty
password, and allow connections to db from localhost only
