### PR TITLE
Remove db creation from fab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+oauth-wikimedia.yaml
+master-db-config.yaml
+deploy-db-config.yaml

--- a/default-db-config.yaml
+++ b/default-db-config.yaml
@@ -1,0 +1,4 @@
+host: wikilabels-database
+user: wikilabels
+database: wikilabels
+password: wikilabels-admin

--- a/labels.wmflabs.org.wsgi
+++ b/labels.wmflabs.org.wsgi
@@ -7,6 +7,9 @@ from wikilabels.wsgi import server
 import yamlconf
 
 config = yamlconf.load(open("labels.wmflabs.org.yaml"))
+# FIXME: DON'T DO THIS
+db_config = config['database']['config']
+config['database'] = yamlconf.load(open(db_config))
 
 application = server.configure(config)
 application.debug = True

--- a/labels.wmflabs.org.yaml
+++ b/labels.wmflabs.org.yaml
@@ -5,6 +5,9 @@ wsgi:
   application_root: ""
   url_prefix: ""
 
+database:
+  config: wikilabels-db-config.yaml
+
 oauth:
   mw_uri: https://www.mediawiki.org/w/index.php
   creds: oauth-wikimedia.yaml

--- a/labels.wmflabs.org.yaml
+++ b/labels.wmflabs.org.yaml
@@ -2,15 +2,8 @@ wikilabels:
   form_directory: forms/enabled
 
 wsgi:
-  host: labels.wmflabs.org
   application_root: ""
   url_prefix: ""
-
-database:
-  host: wikilabels-database
-  user: wikilabels
-  database: wikilabels
-  password: ""
 
 oauth:
   mw_uri: https://www.mediawiki.org/w/index.php


### PR DESCRIPTION
Moved to the central postgres server, and created the db and user
there. So, removing that from fab. This meant the credentials move to
a private file - adding a default db config file as a template

Also adding a gitignore file to make sure not to push real creds
