### PR TITLE
Change database to dbname in db config

### DIFF
--- a/default-db-config.yaml
+++ b/default-db-config.yaml
@@ -1,4 +1,4 @@
 host: wikilabels-database
 user: wikilabels
-database: wikilabels
+dbname: wikilabels
 password: wikilabels-admin

--- a/labels.wmflabs.org.wsgi
+++ b/labels.wmflabs.org.wsgi
@@ -7,9 +7,6 @@ from wikilabels.wsgi import server
 import yamlconf
 
 config = yamlconf.load(open("labels.wmflabs.org.yaml"))
-# FIXME: DON'T DO THIS
-db_config = config['database']['config']
-config['database'] = yamlconf.load(open(db_config))
 
 application = server.configure(config)
 application.debug = True


### PR DESCRIPTION
psycopg2 expects dbname as a param so changing it for consistency
