### PR TITLE
Enable CORS only for Wikimedia websites

### DIFF
--- a/config/00-main.yaml
+++ b/config/00-main.yaml
@@ -6,6 +6,7 @@ wsgi:
   host: labels.wmflabs.org
   application_root: ""
   url_prefix: ""
+  cors_allowed: https\://.+?\.(wikipedia|wikidata)\.org
 
 database:
   host: localhost


### PR DESCRIPTION
First https://github.com/wiki-ai/wikilabels/pull/122 needs to be merged.
I tested it in wikilabels-experiment. Works like a charm.
