### PR TITLE
Extends CORS hosts

### DIFF
--- a/config/00-main.yaml
+++ b/config/00-main.yaml
@@ -6,7 +6,7 @@ wsgi:
   host: labels.wmflabs.org
   application_root: ""
   url_prefix: ""
-  cors_allowed: https\://([^\.\/]+\.)?(wiki[pm]edia|wiki(data|books|versity)|wiktionary)\.org
+  cors_allowed: https://([^\.\/]+\.)?(wiki([pm]edia|data|books|versity|quote|source|news|voyage)|wiktionary|mediawiki)\.org
 
 database:
   host: localhost


### PR DESCRIPTION
```
>>> wikimedia_host = re.compile("https://([^\.\/]+\.)?(wiki([pm]edia|data|books|versity|quote|source|news|voyage)|wiktionary|mediawiki)\.org")>>> wikimedia_host.match("https://wikimedia.org")
<_sre.SRE_Match object at 0x7f82c3e0f9b0>
>>> wikimedia_host.match("https://meta.wikimedia.org")
<_sre.SRE_Match object at 0x7f82c3e0fa48>
>>> wikimedia_host.match("https://commons.wikimedia.org")
<_sre.SRE_Match object at 0x7f82c3e0f9b0>
>>> wikimedia_host.match("https://es.wikipedia.org")
<_sre.SRE_Match object at 0x7f82c3e0fa48>
>>> wikimedia_host.match("https://es.wikibooks.org")
<_sre.SRE_Match object at 0x7f82c3e0f9b0>
>>> wikimedia_host.match("https://es.wiktionary.org")
<_sre.SRE_Match object at 0x7f82c3e0fa48>
>>> wikimedia_host.match("https://es.wikisource.org")
<_sre.SRE_Match object at 0x7f82c3e0f9b0>
>>> wikimedia_host.match("https://mediawiki.org")
<_sre.SRE_Match object at 0x7f82c3e0fa48>
```
