### PR TITLE
made toxicity labels more verbose/clear

### DIFF
--- a/forms/i18n/toxicity/en.json
+++ b/forms/i18n/toxicity/en.json
@@ -1,9 +1,9 @@
 {
-	"@metadata": [],
-	"detox": "Rate the toxicity in this comment:",
-	"detox-very-toxic-label": "Very Toxic",
-	"detox-toxic-label": "Toxic",
-	"detox-natural-label": "Neither",
-	"detox-healthy-label": "Healthy contribution",
-	"detox-very-healthy-label": "Very healthy contribution"
+    "@metadata": [],
+    "detox": "Rate the toxicity in this comment:",
+    "detox-very-toxic-label": "Very Toxic (a very hateful, aggressive or disrespectful comment)",
+    "detox-toxic-label": "Toxic (a rude, disrespectful, or unreasonable comment)",
+    "detox-natural-label": "Neither",
+    "detox-healthy-label": "Healthy  (a reasonable, civil, or polite contribution)",
+    "detox-very-healthy-label": "Very healthy  (a very polite, thoughtful, or helpful contribution)"
 }


### PR DESCRIPTION
During our crowdflower experiments, we found that adding more details to the labels led to higher inter-annotator agreement. I've updated the labels of the form correspondingly.