### PR TITLE
Use wikilabels.db.svc.eqiad.wmflabs as default db host

### DIFF
--- a/config/00-main.yaml
+++ b/config/00-main.yaml
@@ -11,7 +11,7 @@ wsgi:
   cors_allowed: https://([^\.\/]+\.)?(wiki([pm]edia|data|books|versity|quote|source|news|voyage)|wiktionary|mediawiki)\.org
 
 database:
-  host: localhost
+  host: wikilabels.db.svc.eqiad.wmflabs
   dbname: wikilabels
 
 oauth:

--- a/config/localhost/52-database.yaml
+++ b/config/localhost/52-database.yaml
@@ -1,5 +1,6 @@
 # These creditials are intended to be used when testing the local, development
 # version of Wiki Labels.  
 database:
+  host: localhost
   user: wikilabels
   password: wikilabels-admin


### PR DESCRIPTION
Also bumps the wikilabels submodule to take advantage of recent translations. 